### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,7 +22,7 @@
   },
   "modal_width": 700,
   "description": "Export Pointclouds and Pointcloud episodes to ROS Bag format",
-  "docker_image": "supervisely/import-export:6.73.456",
+  "docker_image": "supervisely/import-export:6.73.564",
   "main_script": "src/main.py",
   "task_location": "workspace_tasks",
   "headless": true,

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
   "name": "Export Point Clouds to ROS Bag",
   "type": "app",
   "version": "2.0.0",
-  "instance_version": "6.15.2",
+  "instance_version": "6.15.60",
   "categories": ["pointclouds", "export"],
   "context_menu": {
     "target": [

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
 bagpy==0.5
-supervisely==6.73.456
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
